### PR TITLE
set status for Workflow cancel

### DIFF
--- a/public/db.json
+++ b/public/db.json
@@ -36,21 +36,24 @@
                 "title": "alphafold2",
                 "description": "",
                 "github": "https://github.com/nf-core/proteinfold.git",
-                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json"
+                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json",
+                "revision": "master"
               },
               {
                 "id": 5,
                 "title": "colabfold",
                 "description": "",
                 "github": "https://github.com/nf-core/proteinfold.git",
-                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json"
+                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json",
+                "revision": "master"
               },
               {
                 "id": 6,
                 "title": "esmfold",
                 "description": "",
                 "github": "https://github.com/nf-core/proteinfold.git",
-                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json"
+                "schema": "https://raw.githubusercontent.com/nf-core/proteinfold/refs/tags/1.0.0/nextflow_schema.json",
+                "revision": "master"
               }
             ]
           },

--- a/src/controllers/cancelWorkflow.ts
+++ b/src/controllers/cancelWorkflow.ts
@@ -14,7 +14,7 @@ export async function cancelWorkflow(workflowId: string) {
 
   if (!response.ok) {
     throw new Error(
-      `Fail to list workflow runs: ${response.status} ${data?.message || JSON.stringify(data)}`
+      `Fail to cancel workflow: ${response.status} ${data?.message || JSON.stringify(data)}`
     );
   }
 

--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -25,10 +25,6 @@ export default function MyRuns() {
   const [openDialog, setOpenDialog] = React.useState(false);
   const [selectedId, setSelectedId] = React.useState<string | null>(null);
   const [errorMsg, setErrorMsg] = React.useState("");
-  const handleRowClick = (params: GridRowParams) => {
-    const id = params.row.id;
-    Router.push({ pathname: "/jobs/results", query: { id: id } });
-  };
 
   const fetchRuns = async () => {
     const result = await listRuns();
@@ -109,7 +105,6 @@ export default function MyRuns() {
           <DataGrid
             rows={runs}
             columns={columns}
-            onRowClick={handleRowClick}
             initialState={{
               pagination: {
                 paginationModel: {


### PR DESCRIPTION
Hi @marius-mather, I found enhancements can be done related to workflow cancelation 
The current cancel button (on jobs page) handles workflow cancelation silently.

This PR containing an enhancement in workflow cancel function:
- Add confirmation dialog before actually handling workflow cancelation
- Set loading circular progress when cancel is handling or loading page
Sample is below

https://github.com/user-attachments/assets/95ede092-af42-4ecb-8125-1dcab2e22699

